### PR TITLE
Add custom callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ configs = {
       "logger": False,              # Log results to Weights and Biases (https://www.wandb.com/)
                                     ## wandb offers a very clean and flexible interface to monitor results online
                                     ## A free account is necessary to view and log results
+      "custom_callback": object,    # Extra Skorch callback (optional). Can be used e.g. to add the optuna
+                                    ## Skorch callback, in order to implement pruning (early stopping) while 
+                                    ## performing optuna hyperparameter tuning.
   },
 }
 ```

--- a/amptorch/trainer.py
+++ b/amptorch/trainer.py
@@ -176,6 +176,12 @@ class AtomsTrainer:
                     keys_ignored="dur",
                 )
             )
+
+        # Custom callbacks (e.g. optuna)
+        custom_callback = self.config["cmd"].get("custom_callback")
+        if custom_callback is not None:
+            callbacks.append(custom_callback)
+
         self.callbacks = callbacks
 
     def load_criterion(self):


### PR DESCRIPTION
this PR allows us to easily prune unpromising trials during hyperparameter optimization with optuna (or any other library).

[Example usage](https://github.com/Arrrlex/bdqm-hyperparam-tuning/blob/ca6ab834d6faf370f5a1fabd2838bd73d46f5c5f/ampopt/train.py#L127)